### PR TITLE
Update for public registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,24 @@
 language: node_js
 node_js:
-  - "14"
+- '14'
 cache:
   directories:
-    - node_modules
+  - node_modules
 install:
-  - npm install
+- npm install
 jobs:
   include:
-    - stage: build
-      if: (type IN (pull_request))
-      script: npm run test && npm run build
+  - stage: build
+    if: "(type IN (pull_request))"
+    script: npm run test && npm run build
+deploy:
+  provider: npm
+  email: OpenDevWG@t-mobile.com
+  api_key:
+    secure: o1Ajlq/lG5KeuS3REFum9MbJzJr1MscDknPMg/8owjzZymAseAzhAmPET5KUusPjBfqSHFH6YMMzTJNWtxLxzOqUYGbrlLZn1YREJgWygRQCyN69eMkPh3I7/imlLeG8taA/dagTTUSRh5IW3XmcFMEDqYF+pKvqDPgh4fIoKfmvBKLnZ+aeNAbnI4YIzh8ynAgqLQFrqhPzLn1YPMVsJgc6ZWsqryGtbWRMjXc8ic3VplnoWnBlrCLH/j0X6a/xSt34feBuH1fNfGFKIumhvbCG6yMz6lp4ns50U0SY5OkhZB9npXul0zws+GhNIpH1sH/iDdXDkBs65DAYRlDnlY88RHQ4o1/pE5F4GDtWkcWGw2r1A8b1fV5mgrzeu5W8OiHynVjtC/qBgQHHj7sGfA6J4sJ6CrOq4IMkIkTbUCay/xYhFvGfNENGdh7XXuUisQfv9YoeprHG2jUf22TaSGMxUNlevMJR7uOTYs0iNJVcHBwJIpq+8lsrcgXEj7cPPCCN0pzfToWawm6D0PQjFvko/VpBJ5rwzlOsy+8LrOGJyjmOfP7UOmH+2Jy4Ex9iwkNe4ortU4nLRZ13wcmS5ftfCqpQbWCRaEhqUmU/RZb6MtRdGpLXlf4kQ03I4arfdng4RJmCg3/mzUhZw9FxQa8ekHUdXY7OQi65OB9/C6Y=
+  on:
+    tags: true
+    repo: tmobile/node-red-contrib-array-iterator
+    branch: master
+    tag: stable
+  skip_cleanup: 'true'

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Array Iterator
 
-Given an array input, when this node is executed it will pass the “next” value of the array to the succeeding connected node(s).
+Given an array input, when this node is executed it will pass the “next” value
+of the array to the succeeding connected node(s).
 
 ## Install
 
-> Note: Once public, as with other Node-RED packages this package will be installable through the Node-RED UI. Until then, be sure you follow the [developer instructions](https://gitlab.com/tmobile/iot-mobile/kit/-/blob/tmo/master/developers.md) **before** you try to install any private T-Mobile NPM packages.
-
-<!-- TODO: Once package is public, update instructions -->
-
-```
-cd ~/.node-red
-npm install --save @tmobile/node-red-contrib-array-iterator
-```
+`npm install node-red @tmus/node-red-contrib-array-iterator`
 
 ## Usage
 
-Drag and Drop the "Array Iterator" onto the canvas. Set the `Input` value to the source array and the `output` value to the destination property. Optionally, you can enable `Repeat` to go back to the beginning of the array after the end is reached.
+Drag and Drop the "Array Iterator" onto the canvas. Set the `Input` value to the
+source array and the `output` value to the destination property. Optionally, you
+can enable `Repeat` to go back to the beginning of the array after the end is
+reached.
 
 ### Example
 
-The [example](./example-flow.json) iterates through the three items in the array then stops. To see it in action, [import it](https://nodered.org/docs/user-guide/editor/workspace/import-export) into your Node-RED project.
+The [example](./example-flow.json) iterates through the three items in the array
+then stops. To see it in action, [import
+it](https://nodered.org/docs/user-guide/editor/workspace/import-export) into
+your Node-RED project.
 
 ![Example of Array Iterator](./example-flow.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tmobile/node-red-contrib-array-iterator",
+  "name": "@tmus/node-red-contrib-array-iterator",
   "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@tmobile/node-red-contrib-array-iterator",
-  "version": "0.0.5",
+  "name": "@tmus/node-red-contrib-array-iterator",
+  "version": "0.0.6",
   "description": "Given an array input, when this node is executed it will pass the “next” value of the array to the succeeding connected node(s).",
   "main": "dist/index.js",
   "files": [
@@ -15,14 +15,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://gitlab.com/tmobile/iot-mobile/node-red-packages/array-iterator.git"
+    "url": "git+https://github.com/tmobile/node-red-contrib-array-iterator.git"
   },
   "keywords": [
     "Node-RED",
     "Array Iterator",
     "IoT-Mobile"
   ],
-  "author": "James Tharpe, @jamestharpe",
+  "author": "T-Mobile",
   "license": "Apache-2.0",
   "node-red": {
     "nodes": {
@@ -42,7 +42,8 @@
     "ts-node": "^8.8.2",
     "typescript": "^3.8.3"
   },
-  "publishConfig": {
-    "@tmobile:registry": "https://gitlab.com/api/v4/projects/18231362/packages/npm/"
-  }
+  "bugs": {
+    "url": "https://github.com/tmobile/node-red-contrib-array-iterator/issues"
+  },
+  "homepage": "https://github.com/tmobile/node-red-contrib-array-iterator"
 }


### PR DESCRIPTION
Version 0.06 published by hand: https://www.npmjs.com/package/@tmus/node-red-contrib-array-iterator

Also updated the Travis CI script to auto publish any _tagged releases to master_ - to publish new versions, the use of `npm version <major|minor|patch>` is recommended since that will update the `package.json` version and also apply the appropriate `git tags`