### PR TITLE
Skip devdeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ of the array to the succeeding connected node(s).
 
 ## Install
 
-`cd ~/.node-red && npm install @tmus/node-red-contrib-array-iterator`
+`cd ~/.node-red && npm install --only=prod @tmus/node-red-contrib-array-iterator`
 
 ## Usage
 


### PR DESCRIPTION
Don't install dev dependencies in README instructions - don't need them and it removes confusing warnings.

See convo: https://github.com/tmobile/node-red-contrib-array-iterator/commit/69a1120d23641f7c91ffa86309fad4bc37c70b0c#commitcomment-39703697